### PR TITLE
fix: prevent loading profile with empty userId in MyProfileViewModel

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt
@@ -151,8 +151,6 @@ private fun ProfileContent(
     onLogout: () -> Unit,
     onListingClick: (String) -> Unit
 ) {
-  val profileId = ui.userId ?: ""
-  LaunchedEffect(profileId) { profileViewModel.loadProfile(profileId) }
   val fieldSpacing = 8.dp
 
   LazyColumn(

--- a/app/src/main/java/com/android/sample/ui/profile/MyProfileViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/MyProfileViewModel.kt
@@ -107,7 +107,13 @@ class MyProfileViewModel(
 
   /** Loads the profile data (to be implemented) */
   fun loadProfile(profileUserId: String? = null) {
-    val currentId = profileUserId ?: userId
+    val currentId = profileUserId?.takeIf { it.isNotBlank() } ?: userId
+
+    if (currentId.isBlank()) {
+      Log.w(TAG, "loadProfile called with empty userId; skipping load")
+      return
+    }
+
     viewModelScope.launch {
       try {
         val profile = profileRepository.getProfile(userId = currentId)


### PR DESCRIPTION
### What I did
Fixed the profile screen flicker that occurred after logout/login. The flicker was caused by duplicate profile load calls (one with an empty id) that kept overwriting UI state.

### How I did it
- Removed the redundant `LaunchedEffect` inside `ProfileContent` so the profile is only loaded from the route/top-level `LaunchedEffect` in `MyProfileScreen`.
  - File: `app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt`
- Guarded `loadProfile` in the view model to treat blank/empty `profileUserId` as "not provided" and skip the load (log and return early).
  - File: `app/src/main/java/com/android/sample/ui/profile/MyProfileViewModel.kt`
- The change prevents calls with `""` from overwriting the UI and stops the repeated fetch/recompose loop.

### How to verify it
1. Launch the app and sign in.
2. Navigate to the Profile screen (bottom nav \> Profile).
   - Confirm the profile loads once and the UI is stable (no rapid flickering between profile content and empty state).
3. Tap Logout on the Profile screen.
4. Sign back in with the same account.
5. Navigate again to Profile and confirm the profile loads normally and remains stable.
6. Optional: From the Map/Home, open another user's profile (via profile link) and confirm it loads once and does not flicker.

Files changed:
- `app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt`
- `app/src/main/java/com/android/sample/ui/profile/MyProfileViewModel.kt`

Effect:
- Eliminates the "profile ↔ empty" oscillation and prevents unnecessary fetches with blank IDs.

### Demo video

https://github.com/user-attachments/assets/ae83834c-46b5-4b95-8f6d-813f013aba70


### Pre-merge checklist
The changes I introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested (or have tests added)
