### PR TITLE
Zay1939 feature/add history tab my profile

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/MyProfileScreen.kt
@@ -78,6 +78,8 @@ object MyProfileScreenTestTag {
   const val RATING_TAB = "rankingTab"
   const val RATING_SECTION = "ratingSection"
   const val LISTINGS_TAB = "listingsTab"
+
+  const val HISTORY_TAB = "historyTab"
   const val LISTINGS_SECTION = "listingsSection"
   const val HISTORY_SECTION = "historySection"
 }
@@ -618,13 +620,23 @@ fun SelectionRow(selectedTab: MutableState<ProfileTab>) {
 
   Column(Modifier.fillMaxWidth()) {
     Row(modifier = Modifier.fillMaxWidth().testTag(MyProfileScreenTestTag.INFO_RATING_BAR)) {
-      // Loop through each tab and create a clickable Text
       tabLabels.forEachIndexed { index, label ->
         val tab = ProfileTab.entries[index]
 
+        val tabTestTag =
+            when (tab) {
+              ProfileTab.INFO -> MyProfileScreenTestTag.INFO_TAB
+              ProfileTab.LISTINGS -> MyProfileScreenTestTag.LISTINGS_TAB
+              ProfileTab.RATING -> MyProfileScreenTestTag.RATING_TAB
+              ProfileTab.HISTORY -> MyProfileScreenTestTag.HISTORY_TAB
+            }
+
         Box(
             modifier =
-                Modifier.weight(1f).clickable { selectedTab.value = tab }.padding(vertical = 12.dp),
+                Modifier.weight(1f)
+                    .clickable { selectedTab.value = tab }
+                    .padding(vertical = 12.dp)
+                    .testTag(tabTestTag),
             contentAlignment = Alignment.Center) {
               Text(
                   text = label,


### PR DESCRIPTION
# What I did
- Added a new **History** tab to the MyProfile screen allowing users to see all completed listings.
- Unified the top tab bar into a reusable `SelectionRow` with 4 tabs: Info, Listings, Ratings, History.
- Added the new `ProfileHistory` composable to display completed listings.
- Updated UI tests to cover History tab visibility, navigation, and content rendering (AI generated).

# How I did it
- Extended the `ProfileTab` enum with a new `HISTORY` entry.
- Updated `SelectionRow` to compute dynamic text widths and animate the indicator position.
- Modified the main `MyProfileScreen` to include History in the `when(selectedTab)` switch.
- Implemented `ProfileHistory` as a sibling of Listings & Ratings:
  - Filters listings by `!isActive`
  - Displays cards using existing `ProposalCard` / `RequestCard`
  - Handles loading/error/empty states
- AI generated new Compose UI tests
- Updated existing tests to support the 4-tab layout.

# How to verify it
1. Open My Profile screen with a user that has both active and completed listings.
2. Tap the **History** tab.
3. Confirm:
   - The indicator moves under "History" and centers properly.
   - You see "Your History" at the top.
   - Only non-active (completed) listings appear.
4. Switch between Info → Listings → Ratings → History:
   - Indicator animates smoothly.
   - The correct content loads each time.
5. Test edge case:
   - No completed listings: should show “You don’t have any completed listings yet.”

# Demo video
https://github.com/user-attachments/assets/dd5654f7-f637-490c-8ccb-522fad333621

# Pre-merge checklist
The changes I introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested (or have tests added)
