### PR TITLE
fix(auth-ui): apply auth screen user feedback

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -172,8 +172,17 @@ fun MainApp(authViewModel: AuthenticationViewModel, onGoogleSignIn: () -> Unit) 
   // Check if current route should show bottom nav
   val showBottomNav = mainScreenRoutes.contains(currentRoute)
 
+  val noTopBarRoutes =
+      setOf(
+          NavRoutes.LOGIN,
+      )
+
   Scaffold(
-      topBar = { TopAppBar(navController) },
+      topBar = {
+        if (!noTopBarRoutes.contains(currentRoute)) {
+          TopAppBar(navController)
+        }
+      },
       bottomBar = {
         if (showBottomNav) {
           BottomNavBar(navController)

--- a/app/src/main/java/com/android/sample/ui/components/LocationInputField.kt
+++ b/app/src/main/java/com/android/sample/ui/components/LocationInputField.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.android.sample.model.map.Location
@@ -145,7 +144,7 @@ fun RoundEdgedLocationInputField(
           onLocationQueryChange(it)
           showDropdown = true
         },
-        placeholder = { Text("Address", fontWeight = FontWeight.Bold) },
+        placeholder = { Text("Address") },
         singleLine = true,
         shape = shape,
         colors = colors,

--- a/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
@@ -49,6 +49,8 @@ fun TopAppBar(navController: NavController) {
   val currentDestination = navBackStackEntry?.destination
   val currentRoute = currentDestination?.route
 
+  if (currentRoute == NavRoutes.LOGIN) return
+
   val title =
       when (currentRoute) {
         NavRoutes.HOME -> "Home"

--- a/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
@@ -48,9 +48,6 @@ fun TopAppBar(navController: NavController) {
   val navBackStackEntry by navController.currentBackStackEntryAsState()
   val currentDestination = navBackStackEntry?.destination
   val currentRoute = currentDestination?.route
-
-  if (currentRoute == NavRoutes.LOGIN) return
-
   val title =
       when (currentRoute) {
         NavRoutes.HOME -> "Home"

--- a/app/src/main/java/com/android/sample/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/signup/SignUpScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material3.*
@@ -131,6 +130,21 @@ fun SignUpScreen(vm: SignUpViewModel, onSubmitSuccess: () -> Unit = {}) {
               maxPreviewLength = 45,
               style = EllipsizingTextFieldStyle(shape = fieldShape, colors = fieldColors))
 
+          TextField(
+              value = state.email,
+              onValueChange = {
+                if (!state.isGoogleSignUp) {
+                  vm.onEvent(SignUpEvent.EmailChanged(it))
+                }
+              },
+              modifier = Modifier.fillMaxWidth().testTag(SignUpScreenTestTags.EMAIL),
+              placeholder = { Text("Email Address") },
+              singleLine = true,
+              shape = fieldShape,
+              colors = fieldColors,
+              enabled = !state.isGoogleSignUp, // Disable email field if pre-filled from Google
+              readOnly = state.isGoogleSignUp) // Make it read-only for Google sign-ups
+
           // Location input with Nominatim search and dropdown
           val context = LocalContext.current
           val permission = android.Manifest.permission.ACCESS_FINE_LOCATION
@@ -179,9 +193,7 @@ fun SignUpScreen(vm: SignUpViewModel, onSubmitSuccess: () -> Unit = {}) {
               value = state.levelOfEducation,
               onValueChange = { vm.onEvent(SignUpEvent.LevelOfEducationChanged(it)) },
               modifier = Modifier.fillMaxWidth().testTag(SignUpScreenTestTags.LEVEL_OF_EDUCATION),
-              placeholder = {
-                Text("Major, Year (e.g. CS, 3rd year)", fontWeight = FontWeight.Bold)
-              },
+              placeholder = { Text("Major, Year (e.g. CS, 3rd year)") },
               singleLine = true,
               shape = fieldShape,
               colors = fieldColors)
@@ -193,25 +205,9 @@ fun SignUpScreen(vm: SignUpViewModel, onSubmitSuccess: () -> Unit = {}) {
                   Modifier.fillMaxWidth()
                       .heightIn(min = 112.dp)
                       .testTag(SignUpScreenTestTags.DESCRIPTION),
-              placeholder = { Text("Short description of yourself", fontWeight = FontWeight.Bold) },
+              placeholder = { Text("Short description of yourself") },
               shape = fieldShape,
               colors = fieldColors)
-
-          TextField(
-              value = state.email,
-              onValueChange = {
-                if (!state.isGoogleSignUp) {
-                  vm.onEvent(SignUpEvent.EmailChanged(it))
-                }
-              },
-              modifier = Modifier.fillMaxWidth().testTag(SignUpScreenTestTags.EMAIL),
-              placeholder = { Text("Email Address", fontWeight = FontWeight.Bold) },
-              singleLine = true,
-              leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) },
-              shape = fieldShape,
-              colors = fieldColors,
-              enabled = !state.isGoogleSignUp, // Disable email field if pre-filled from Google
-              readOnly = state.isGoogleSignUp) // Make it read-only for Google sign-ups
 
           // Only show password field if user is not signing up via Google
           if (!state.isGoogleSignUp) {
@@ -219,7 +215,7 @@ fun SignUpScreen(vm: SignUpViewModel, onSubmitSuccess: () -> Unit = {}) {
                 value = state.password,
                 onValueChange = { vm.onEvent(SignUpEvent.PasswordChanged(it)) },
                 modifier = Modifier.fillMaxWidth().testTag(SignUpScreenTestTags.PASSWORD),
-                placeholder = { Text("Password", fontWeight = FontWeight.Bold) },
+                placeholder = { Text("Password") },
                 singleLine = true,
                 leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
                 visualTransformation = PasswordVisualTransformation(),


### PR DESCRIPTION
# What I did
Removed top bar on SignIn screen and reordered fields on SignUp (email directly under name). Updated fields typography to stay consistent throughout the whole sign up.

# How I did it
- Added route checks to hide `TopAppBar` on SignIn.
- Moved email/password block in `SignUpScreen` under the name input.
- Updated fields to use normal text weight instead of bold.

# How to verify it
1. Navigate to **SignIn** → confirm top bar is hidden.
2. Navigate to **SignUp** → check new field order (Name → Email → Surname…).
3. Confirm field inputs are no longer bold.


# Pre-merge checklist
The changes I introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested (or have tests added)
