### PR TITLE
sanemsarioglu-fix/show ratings in the profile page

### DIFF
--- a/app/src/androidTest/java/com/android/sample/navigation/NavGraphCoverageTest.kt
+++ b/app/src/androidTest/java/com/android/sample/navigation/NavGraphCoverageTest.kt
@@ -10,6 +10,10 @@ import com.android.sample.model.listing.Listing
 import com.android.sample.model.listing.ListingRepository
 import com.android.sample.model.listing.Proposal
 import com.android.sample.model.listing.Request
+import com.android.sample.model.rating.Rating
+import com.android.sample.model.rating.RatingRepository
+import com.android.sample.model.rating.RatingRepositoryProvider
+import com.android.sample.model.rating.RatingType
 import com.android.sample.model.skill.MainSubject
 import com.android.sample.model.user.Profile
 import com.android.sample.model.user.ProfileRepository
@@ -47,6 +51,7 @@ class NavGraphCoverageTest {
     mockkStatic(FirebaseAuth::class)
     staticAuth = mockk(relaxed = true)
     every { FirebaseAuth.getInstance() } returns staticAuth
+    RatingRepositoryProvider.setForTests(FakeRatingRepo())
   }
 
   @After
@@ -66,6 +71,9 @@ class NavGraphCoverageTest {
     } catch (_: Throwable) {}
     try {
       unmockkStatic("com.android.sample.MainActivityKt")
+    } catch (_: Throwable) {}
+    try {
+      com.android.sample.model.rating.RatingRepositoryProvider.clearForTests()
     } catch (_: Throwable) {}
   }
 
@@ -115,6 +123,39 @@ class NavGraphCoverageTest {
         location: com.android.sample.model.map.Location,
         radiusKm: Double
     ): List<Listing> = emptyList()
+  }
+
+  private class FakeRatingRepo : RatingRepository {
+    override fun getNewUid(): String = "fake-rating-uid"
+
+    override suspend fun getAllRatings(): List<Rating> = emptyList()
+
+    override suspend fun getRating(ratingId: String): Rating? = null
+
+    override suspend fun getRatingsByFromUser(fromUserId: String): List<Rating> = emptyList()
+
+    override suspend fun getRatingsByToUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun getRatingsOfListing(listingId: String): List<Rating> = emptyList()
+
+    override suspend fun addRating(rating: Rating) {}
+
+    override suspend fun updateRating(ratingId: String, rating: Rating) {}
+
+    override suspend fun deleteRating(ratingId: String) {}
+
+    override suspend fun getTutorRatingsOfUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun getStudentRatingsOfUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun deleteAllRatingOfUser(userId: String) {}
+
+    override suspend fun hasRating(
+        fromUserId: String,
+        toUserId: String,
+        ratingType: RatingType,
+        targetObjectId: String
+    ): Boolean = false
   }
 
   // Helper to create a properly mocked BookingDetailsViewModel with a real StateFlow

--- a/app/src/androidTest/java/com/android/sample/screen/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/ProfileScreenTest.kt
@@ -6,11 +6,8 @@ import com.android.sample.model.listing.ListingRepository
 import com.android.sample.model.listing.Proposal
 import com.android.sample.model.listing.Request
 import com.android.sample.model.map.Location
-import com.android.sample.model.rating.Rating
 import com.android.sample.model.rating.RatingInfo
-import com.android.sample.model.rating.RatingRepository
 import com.android.sample.model.rating.RatingRepositoryProvider
-import com.android.sample.model.rating.RatingType
 import com.android.sample.model.skill.ExpertiseLevel
 import com.android.sample.model.skill.MainSubject
 import com.android.sample.model.skill.Skill
@@ -19,7 +16,9 @@ import com.android.sample.model.user.ProfileRepository
 import com.android.sample.ui.profile.ProfileScreen
 import com.android.sample.ui.profile.ProfileScreenTestTags
 import com.android.sample.ui.profile.ProfileScreenViewModel
+import com.android.sample.utils.fakeRepo.fakeRating.RatingFakeRepoWorking
 import java.util.Date
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -31,41 +30,12 @@ class ProfileScreenTest {
 
   @Before
   fun initRatingProviderForTests() {
-    RatingRepositoryProvider.setForTests(FakeRatingRepository())
+    RatingRepositoryProvider.setForTests(RatingFakeRepoWorking())
   }
 
-  // Minimal fake implementation used for tests
-  private class FakeRatingRepository : RatingRepository {
-    override fun getNewUid(): String = "fake-rating-uid"
-
-    override suspend fun getAllRatings(): List<Rating> = emptyList()
-
-    override suspend fun getRating(ratingId: String): Rating? = null
-
-    override suspend fun getRatingsByFromUser(fromUserId: String): List<Rating> = emptyList()
-
-    override suspend fun getRatingsByToUser(userId: String): List<Rating> = emptyList()
-
-    override suspend fun getRatingsOfListing(listingId: String): List<Rating> = emptyList()
-
-    override suspend fun addRating(rating: Rating) {}
-
-    override suspend fun updateRating(ratingId: String, rating: Rating) {}
-
-    override suspend fun deleteRating(ratingId: String) {}
-
-    override suspend fun getTutorRatingsOfUser(userId: String): List<Rating> = emptyList()
-
-    override suspend fun getStudentRatingsOfUser(userId: String): List<Rating> = emptyList()
-
-    override suspend fun deleteAllRatingOfUser(userId: String) {}
-
-    override suspend fun hasRating(
-        fromUserId: String,
-        toUserId: String,
-        ratingType: RatingType,
-        targetObjectId: String
-    ): Boolean = false
+  @After
+  fun cleanupRatingProvider() {
+    RatingRepositoryProvider.clearForTests()
   }
 
   private val sampleProfile =

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
@@ -260,6 +260,8 @@ private fun ProfileContent(
                                         "%.1f (%d)",
                                         uiState.tutorAvg,
                                         uiState.tutorCount),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
                                 modifier =
                                     Modifier.testTag(ProfileScreenTestTags.TUTOR_RATING_VALUE))
                           }
@@ -290,6 +292,8 @@ private fun ProfileContent(
                                         "%.1f (%d)",
                                         uiState.studentAvg,
                                         uiState.studentCount),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
                                 modifier =
                                     Modifier.testTag(ProfileScreenTestTags.STUDENT_RATING_VALUE))
                           }

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
@@ -23,10 +23,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.model.listing.ListingRepositoryProvider
+import com.android.sample.model.rating.RatingRepositoryProvider
 import com.android.sample.model.user.ProfileRepositoryProvider
 import com.android.sample.ui.components.ProposalCard
 import com.android.sample.ui.components.RatingStars
 import com.android.sample.ui.components.RequestCard
+import java.util.Locale
 
 object ProfileScreenTestTags {
   const val SCREEN = "ProfileScreenTestTags.SCREEN"
@@ -74,7 +76,8 @@ fun ProfileScreen(
     viewModel: ProfileScreenViewModel = viewModel {
       ProfileScreenViewModel(
           profileRepository = ProfileRepositoryProvider.repository,
-          listingRepository = ListingRepositoryProvider.repository)
+          listingRepository = ListingRepositoryProvider.repository,
+          ratingRepository = RatingRepositoryProvider.repository)
     }
 ) {
   // Properly observe StateFlow in Compose
@@ -248,15 +251,15 @@ private fun ProfileContent(
                                 fontWeight = FontWeight.SemiBold,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer)
                             Spacer(modifier = Modifier.height(8.dp))
-                            RatingStars(ratingOutOfFive = profile.tutorRating.averageRating)
+                            RatingStars(ratingOutOfFive = uiState.tutorAvg)
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
                                 text =
                                     String.format(
-                                        "%.1f (${profile.tutorRating.totalRatings})",
-                                        profile.tutorRating.averageRating),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        Locale.US,
+                                        "%.1f (%d)",
+                                        uiState.tutorAvg,
+                                        uiState.tutorCount),
                                 modifier =
                                     Modifier.testTag(ProfileScreenTestTags.TUTOR_RATING_VALUE))
                           }
@@ -278,15 +281,15 @@ private fun ProfileContent(
                                 fontWeight = FontWeight.SemiBold,
                                 color = MaterialTheme.colorScheme.onSecondaryContainer)
                             Spacer(modifier = Modifier.height(8.dp))
-                            RatingStars(ratingOutOfFive = profile.studentRating.averageRating)
+                            RatingStars(ratingOutOfFive = uiState.studentAvg)
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
                                 text =
                                     String.format(
-                                        "%.1f (${profile.studentRating.totalRatings})",
-                                        profile.studentRating.averageRating),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                        Locale.US,
+                                        "%.1f (%d)",
+                                        uiState.studentAvg,
+                                        uiState.studentCount),
                                 modifier =
                                     Modifier.testTag(ProfileScreenTestTags.STUDENT_RATING_VALUE))
                           }

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreenViewModel.kt
@@ -6,6 +6,9 @@ import androidx.lifecycle.viewModelScope
 import com.android.sample.model.listing.ListingRepository
 import com.android.sample.model.listing.Proposal
 import com.android.sample.model.listing.Request
+import com.android.sample.model.rating.Rating
+import com.android.sample.model.rating.RatingRepository
+import com.android.sample.model.rating.RatingType
 import com.android.sample.model.user.Profile
 import com.android.sample.model.user.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,12 +21,17 @@ data class ProfileScreenUiState(
     val profile: Profile? = null,
     val proposals: List<Proposal> = emptyList(),
     val requests: List<Request> = emptyList(),
+    val tutorAvg: Double = 0.0,
+    val tutorCount: Int = 0,
+    val studentAvg: Double = 0.0,
+    val studentCount: Int = 0,
     val errorMessage: String? = null
 )
 
 class ProfileScreenViewModel(
     private val profileRepository: ProfileRepository,
-    private val listingRepository: ListingRepository
+    private val listingRepository: ListingRepository,
+    private val ratingRepository: RatingRepository
 ) : ViewModel() {
 
   private val _uiState = MutableStateFlow(ProfileScreenUiState())
@@ -56,12 +64,28 @@ class ProfileScreenViewModel(
         val proposals = listings.filterIsInstance<Proposal>()
         val requests = listings.filterIsInstance<Request>()
 
+        val allRatings = ratingRepository.getRatingsByToUser(userId)
+
+        val tutorRatings = allRatings.filter { it.ratingType == RatingType.TUTOR }
+        val studentRatings = allRatings.filter { it.ratingType == RatingType.STUDENT }
+
+        fun avg(list: List<Rating>): Double =
+            if (list.isEmpty()) 0.0
+            else list.map { (it.starRating.ordinal + 1).toDouble() }.average()
+
+        val tutorAvg = avg(tutorRatings)
+        val studentAvg = avg(studentRatings)
+
         _uiState.value =
             _uiState.value.copy(
                 isLoading = false,
                 profile = profile,
                 proposals = proposals,
                 requests = requests,
+                tutorAvg = tutorAvg,
+                tutorCount = tutorRatings.size,
+                studentAvg = studentAvg,
+                studentCount = studentRatings.size,
                 errorMessage = null)
       } catch (e: Exception) {
         _uiState.value =
@@ -79,12 +103,14 @@ class ProfileScreenViewModel(
   companion object {
     fun provideFactory(
         profileRepository: ProfileRepository,
-        listingRepository: ListingRepository
+        listingRepository: ListingRepository,
+        ratingRepository: RatingRepository
     ): ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {
           @Suppress("UNCHECKED_CAST")
           override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ProfileScreenViewModel(profileRepository, listingRepository) as T
+            return ProfileScreenViewModel(profileRepository, listingRepository, ratingRepository)
+                as T
           }
         }
   }

--- a/app/src/test/java/com/android/sample/screen/ProfileScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/screen/ProfileScreenViewModelTest.kt
@@ -4,7 +4,11 @@ import com.android.sample.model.listing.ListingRepository
 import com.android.sample.model.listing.Proposal
 import com.android.sample.model.listing.Request
 import com.android.sample.model.map.Location
+import com.android.sample.model.rating.Rating
 import com.android.sample.model.rating.RatingInfo
+import com.android.sample.model.rating.RatingRepository
+import com.android.sample.model.rating.RatingRepositoryProvider
+import com.android.sample.model.rating.RatingType
 import com.android.sample.model.skill.ExpertiseLevel
 import com.android.sample.model.skill.MainSubject
 import com.android.sample.model.skill.Skill
@@ -32,6 +36,7 @@ class ProfileScreenViewModelTest {
   @Before
   fun setUp() {
     Dispatchers.setMain(dispatcher)
+    RatingRepositoryProvider.setForTests(FakeRatingRepository())
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -139,6 +144,39 @@ class ProfileScreenViewModelTest {
         emptyList<com.android.sample.model.listing.Listing>()
   }
 
+  class FakeRatingRepository : RatingRepository {
+    override fun getNewUid(): String = "fake-rating-uid"
+
+    override suspend fun getAllRatings(): List<Rating> = emptyList()
+
+    override suspend fun getRating(ratingId: String): Rating? = null
+
+    override suspend fun getRatingsByFromUser(fromUserId: String): List<Rating> = emptyList()
+
+    override suspend fun getRatingsByToUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun getRatingsOfListing(listingId: String): List<Rating> = emptyList()
+
+    override suspend fun addRating(rating: Rating) {}
+
+    override suspend fun updateRating(ratingId: String, rating: Rating) {}
+
+    override suspend fun deleteRating(ratingId: String) {}
+
+    override suspend fun getTutorRatingsOfUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun getStudentRatingsOfUser(userId: String): List<Rating> = emptyList()
+
+    override suspend fun deleteAllRatingOfUser(userId: String) {}
+
+    override suspend fun hasRating(
+        fromUserId: String,
+        toUserId: String,
+        ratingType: RatingType,
+        targetObjectId: String
+    ): Boolean = false
+  }
+
   // -------- Helpers ------------------------------------------------------
 
   private fun makeProfile(
@@ -194,7 +232,9 @@ class ProfileScreenViewModelTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun initialState_isLoading() {
-    val vm = ProfileScreenViewModel(FakeProfileRepository(), FakeListingRepository())
+    val vm =
+        ProfileScreenViewModel(
+            FakeProfileRepository(), FakeListingRepository(), RatingRepositoryProvider.repository)
 
     val state = vm.uiState.value
     assertTrue(state.isLoading)
@@ -216,7 +256,7 @@ class ProfileScreenViewModelTest {
     val listingRepo =
         FakeListingRepository(mutableListOf(proposal1, proposal2), mutableListOf(request1))
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()
@@ -240,7 +280,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(null)
     val listingRepo = FakeListingRepository()
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile("non-existent-user")
     advanceUntilIdle()
@@ -260,7 +300,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(profile)
     val listingRepo = FakeListingRepository()
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()
@@ -283,7 +323,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(profile)
     val listingRepo = FakeListingRepository(mutableListOf(proposal1, proposal2))
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()
@@ -303,7 +343,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(profile)
     val listingRepo = FakeListingRepository(storedRequests = mutableListOf(request1, request2))
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()
@@ -322,7 +362,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(profile)
     val listingRepo = FakeListingRepository(mutableListOf(proposal))
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()
@@ -356,7 +396,7 @@ class ProfileScreenViewModelTest {
         FakeListingRepository(
             mutableListOf(user1Proposal, user2Proposal), mutableListOf(user2Request))
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile("user-2")
     advanceUntilIdle()
@@ -378,7 +418,7 @@ class ProfileScreenViewModelTest {
     val profileRepo = FakeProfileRepository(profile)
     val listingRepo = FakeListingRepository()
 
-    val vm = ProfileScreenViewModel(profileRepo, listingRepo)
+    val vm = ProfileScreenViewModel(profileRepo, listingRepo, RatingRepositoryProvider.repository)
 
     vm.loadProfile(profile.userId)
     advanceUntilIdle()

--- a/app/src/test/java/com/android/sample/screen/ProfileScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/screen/ProfileScreenViewModelTest.kt
@@ -43,6 +43,7 @@ class ProfileScreenViewModelTest {
   @After
   fun tearDown() {
     Dispatchers.resetMain()
+    RatingRepositoryProvider.clearForTests()
   }
 
   // -------- Fake Repositories ------------------------------------------------------


### PR DESCRIPTION
# What I did
I fixed the Profile page so that tutor and student ratings are correctly displayed instead of always showing empty or default values.

Previously, the Profile screen did not load rating data, so the “As Tutor” and “As Student” sections were not reflecting actual user ratings.
# How I did it

- Extended ProfileScreenViewModel to fetch ratings for the viewed user using RatingRepository.
- Filtered ratings by RatingType.TUTOR and RatingType.STUDENT.
- Computed the average star rating and total count for each role.
- Exposed the computed values through ProfileScreenUiState.
- Updated ProfileScreen UI to use the computed averages from the UI state instead of relying on profile defaults.
- Ensured correct numeric formatting and proper state handling during loading and error cases.


# How to verify it

1. Open a user’s Profile page.
2. Scroll to the ratings section.

3. Verify that:
      The “As Tutor” rating shows the correct star average and count.
      The “As Student” rating shows the correct star average and count.
4. Test with:
      A user who has ratings.
      A user with no ratings (should show 0.0 (0) and empty stars).

# Demo video
<img width="337" height="648" alt="Screenshot 2025-12-17 at 14 17 23" src="https://github.com/user-attachments/assets/257f687c-9c5a-4faf-b720-3082d89f35a2" />

# Pre-merge checklist
The changes I introduced:
- [x] work correctly
- [x] do not break other functionalities
- [x] work correctly on Android
- [x] are fully tested (or have tests added)